### PR TITLE
SimpleTypes 와 String50Spec, EmailAddressSpec 추가

### DIFF
--- a/src/main/kotlin/org/ontheground/dmmf/ordertaking/SimpleTypes.kt
+++ b/src/main/kotlin/org/ontheground/dmmf/ordertaking/SimpleTypes.kt
@@ -1,0 +1,381 @@
+package org.ontheground.dmmf.ordertaking
+
+import arrow.core.*
+
+// ===============================
+// Simple types and constrained types related to the OrderTaking domain.
+//
+// E.g. Single case discriminated unions (aka wrappers), enums, etc
+// ===============================
+
+fun Throwable.withFieldName(fieldName: String): Throwable {
+    val newMessage = "$fieldName: ${this.message}"
+    return Exception(newMessage, this)
+}
+
+/// Constrained to be 50 chars or less, not null
+@JvmInline
+value class String50(val value: String) {
+    /// Create a String50 from a string
+    /// Return Error if input is null, empty, or length > 50
+    init {
+        ConstrainedType.requireStringMaxLen(50)(value)
+    }
+
+    companion object {
+        /// Create a String50 from a string
+        /// Return None if input is null, empty.
+        /// Return error if length > maxLen
+        /// Return Some if the input is valid
+        fun createOption(str: String): Either<Throwable, Option<String50>> {
+            /// Create an optional constrained string using the constructor provided
+            /// Return None if input is null, empty.
+            /// Return error if length > maxLen
+            /// Return Some if the input is valid
+            return Either.catch { String50(str).some().right() }
+                .getOrElse { e: Throwable ->
+                    if (ConstrainedType.isEmptyStringError(e)) None.right()
+                    else e.left()
+                }
+        }
+    }
+}
+
+///// An email address
+@JvmInline
+value class EmailAddress(val value: String) {
+    /// Create an EmailAddress from a string
+    /// Return Error if input is null, empty, or doesn't have an "@" in it
+    init {
+        ConstrainedType.requireStringLike(".+@.+")(value)
+    }
+}
+
+/// A zip code
+@JvmInline
+value class ZipCode private constructor(val value: String) {
+    init {
+        ConstrainedType.requireStringLike("""\d{5}""")(value)
+    }
+
+    companion object {
+        /// Create a ZipCode from a string
+        /// Return Error if input is null, empty, or doesn't have 5 digits
+        operator fun invoke(fieldName: String): (String) -> Either<Throwable, ZipCode> {
+            return { str ->
+                Either.catch { ZipCode(str) }
+                    .mapLeft { e: Throwable -> e.withFieldName(fieldName) }
+            }
+        }
+    }
+}
+
+/// An Id for Orders. Constrained to be a non-empty string <= 50 chars
+@JvmInline
+value class OrderId private constructor(val value: String) {
+    init {
+        ConstrainedType.requireStringMaxLen(50)(value)
+    }
+
+    companion object {
+        /// Create an OrderId from a string
+        /// Return Error if input is null, empty, or length > 50
+        operator fun invoke(fieldName: String): (String) -> Either<Throwable, OrderId> {
+            return { str ->
+                Either.catch { OrderId(str) }
+                    .mapLeft { e: Throwable -> e.withFieldName(fieldName) }
+            }
+        }
+    }
+}
+
+/// An Id for OrderLines. Constrained to be a non-empty string <= 50 chars
+@JvmInline
+value class OrderLineId private constructor(val value: String) {
+    init {
+        ConstrainedType.requireStringMaxLen(50)(value)
+    }
+
+    companion object {
+        /// Create an OrderLineId from a string
+        /// Return Error if input is null, empty, or length > 50
+        operator fun invoke(fieldName: String): (String) -> Either<Throwable, OrderLineId> {
+            return { str ->
+                Either.catch { OrderLineId(str) }
+                    .mapLeft { e: Throwable -> e.withFieldName(fieldName) }
+            }
+        }
+    }
+}
+
+/// The codes for Widgets start with a "W" and then four digits
+@JvmInline
+value class WidgetCode private constructor(val value: String) {
+    init {
+        ConstrainedType.requireStringLike("""W\d{4}""")(value)
+    }
+
+    companion object {
+        /// Create an WidgetCode from a string
+        /// Return Error if input is null. empty, or not matching pattern
+        operator fun invoke(fieldName: String): (String) -> Either<Throwable, WidgetCode> {
+            // The codes for Widgets start with a "W" and then four digits
+            return { str ->
+                Either.catch { WidgetCode(str) }
+                    .mapLeft { e: Throwable -> e.withFieldName(fieldName) }
+            }
+        }
+    }
+
+}
+
+/// The codes for Gizmos start with a "G" and then three digits.
+@JvmInline
+value class GizmoCode private constructor(val value: String) {
+    init {
+        ConstrainedType.requireStringLike("""G\d{3}""")(value)
+    }
+
+    companion object {
+        /// Create an GizmoCode from a string
+        /// Return Error if input is null, empty, or not matching pattern
+        operator fun invoke(fieldName: String): (String) -> Either<Throwable, GizmoCode> {
+            // The codes for Gizmos start with a "G" and then three digits.
+            return { str ->
+                Either.catch { GizmoCode(str) }
+                    .mapLeft { e: Throwable -> e.withFieldName(fieldName) }
+            }
+        }
+    }
+}
+
+///// A ProductCode is either a Widget or a Gizmo
+sealed interface ProductCode {
+    /// Return the string value inside a ProductCode
+    fun value() {
+        when (this) {
+            is Widget -> this.value.value
+            is Gizmo -> this.value.value
+        }
+    }
+}
+
+@JvmInline
+value class Widget(val value: WidgetCode) : ProductCode
+
+@JvmInline
+value class Gizmo(val value: GizmoCode) : ProductCode
+
+/// Create an ProductCode from a string
+/// Return Error if input is null, empty, or not matching pattern
+fun createProductCode(
+    fieldName: String,
+): (String) -> Either<Throwable, ProductCode> {
+    return { code ->
+        if (code.isNullOrEmpty()) Throwable("${fieldName}: Must not be null or empty").left()
+        else if (code.startsWith("W")) WidgetCode(fieldName)(code).map { w -> Widget(w) }
+        else if (code.startsWith("G")) GizmoCode(fieldName)(code).map { g -> Gizmo(g) }
+        else Throwable("${fieldName}: Format not recognized '${code}'").left()
+    }
+}
+
+
+/// Constrained to be a integer between 1 and 1000
+@JvmInline
+value class UnitQuantity private constructor(val value: Int) {
+    init {
+        ConstrainedType.requireIntInBetween(1, 1000)(value)
+    }
+
+    companion object {
+        /// Create a UnitQuantity from a int
+        /// Return Error if input is not an integer between 1 and 1000
+        operator fun invoke(fieldName: String): (Int) -> Either<Throwable, UnitQuantity> {
+            return { i ->
+                Either.catch { UnitQuantity(i) }
+                    .mapLeft { e: Throwable -> e.withFieldName(fieldName) }
+            }
+        }
+    }
+}
+
+/// Constrained to be a decimal between 0.05 and 100.00
+@JvmInline
+value class KilogramQuantity private constructor(val value: Double) {
+    init {
+        ConstrainedType.requireDoubleInBetween(0.05, 100.00)(value)
+    }
+
+    companion object {
+        /// Create a KilogramQuantity from a decimal.
+        /// Return Error if input is not a decimal between 0.05 and 100.00
+        operator fun invoke(fieldName: String): (Double) -> Either<Throwable, KilogramQuantity> {
+            return { i ->
+                Either.catch { KilogramQuantity(i) }
+                    .mapLeft { e: Throwable -> e.withFieldName(fieldName) }
+            }
+        }
+    }
+}
+
+/// A Quantity is either a Unit or a Kilogram
+sealed interface OrderQuantity {
+    /// Return the value inside a OrderQuantity
+    fun value(qty: OrderQuantity): Double {
+        return when (qty) {
+            is Unit -> qty.value.value.toDouble()
+            is Kilogram -> qty.value.value
+        }
+    }
+}
+
+@JvmInline
+value class Unit(val value: UnitQuantity) : OrderQuantity
+
+@JvmInline
+value class Kilogram(val value: KilogramQuantity) : OrderQuantity
+
+/// Create a OrderQuantity from a productCode and quantity
+fun createOrderQuantity(
+    fieldName: String,
+    productCode: ProductCode,
+): (Double) -> Either<Throwable, OrderQuantity> {
+    return { quantity ->
+        when (productCode) {
+            is Widget -> UnitQuantity(fieldName)(quantity.toInt()).map { u -> Unit(u) } // lift to OrderQuantity type
+            is Gizmo -> KilogramQuantity(fieldName)(quantity).map { u -> Kilogram(u) } // lift to OrderQuantity type
+        }
+    }
+}
+
+
+/// Constrained to be a decimal between 0.0 and 1000.00
+@JvmInline
+value class Price private constructor(val value: Double) {
+    init {
+        /// Create a Price from a decimal.
+        /// Return Error if input is not a decimal between 0.0 and 1000.00
+        ConstrainedType.requireDoubleInBetween(0.0, 1000.00)(value)
+    }
+
+    /// Multiply a Price by a decimal qty.
+    /// Return Error if new price is out of bounds.
+    fun multiply(qty: Double): Price {
+        return Price(qty * this.value)
+    }
+
+
+    companion object {
+        operator fun invoke(fieldName: String): (Double) -> Either<Throwable, Price> {
+            /// Create a Price from a decimal.
+            /// Throw an exception if out of bounds. This should only be used if you know the value is valid.
+            return { p ->
+                Either.catch { Price(p) }
+                    .mapLeft { e: Throwable -> e.withFieldName(fieldName) }
+            }
+        }
+
+        fun unsafeCreate(fieldName: String): (Double) -> Price {
+            /// Create a Price from a decimal.
+            /// Throw an exception if out of bounds. This should only be used if you know the value is valid.
+            return { p ->
+                try {
+                    Price(p)
+                } catch (e: Throwable) {
+                    throw Throwable(message = "Not expecting Price to be out of bounds", cause = e)
+                }
+            }
+        }
+    }
+}
+
+/// Constrained to be a decimal between 0.0 and 10000.00
+@JvmInline
+value class BillingAmount private constructor(val value: Double) {
+    init {
+        ConstrainedType.requireDoubleInBetween(0.0, 10000.00)(value)
+    }
+
+    companion object {
+        /// Create a BillingAmount from a decimal.
+        /// Return Error if input is not a decimal between 0.0 and 10000.00
+        operator fun invoke(fieldName: String): (Double) -> Either<Throwable, BillingAmount> {
+            return { i ->
+                Either.catch { BillingAmount(i) }
+                    .mapLeft { e: Throwable -> e.withFieldName(fieldName) }
+            }
+        }
+
+        /// Sum a list of prices to make a billing amount
+        /// Return Error if total is out of bounds
+        fun sumPrices(prices: Array<Price>): BillingAmount {
+            return BillingAmount(prices.sumOf { p -> p.value })
+        }
+    }
+}
+
+/// Represents a PDF attachment
+class PdfAttachment(
+    val Name: String,
+    val Bytes: ByteArray,
+)
+
+
+// ===============================
+// Reusable constructors and getters for constrained types
+// ===============================
+
+/// Useful functions for constrained types
+object ConstrainedType {
+    private val isEmptyStringErrorMessage = "Must not be null or empty"
+
+    fun isEmptyStringError(e: Throwable): Boolean {
+        return e.message == isEmptyStringErrorMessage
+    }
+
+    /// Create a constrained string using the constructor provided
+    /// Return Error if input is null, empty, or length > maxLen
+    fun requireStringMaxLen(
+        maxLen: Int
+    ): (String) -> kotlin.Unit {
+        return { str ->
+            require(!str.isNullOrEmpty(), { isEmptyStringErrorMessage })
+            require(str.length <= maxLen, { "Must not be more than ${maxLen} chars" })
+        }
+    }
+
+    /// Create a constrained integer using the constructor provided
+    /// Return Error if input is less than minVal or more than maxVal
+    fun requireIntInBetween(
+        minVal: Int,
+        maxVal: Int,
+    ): (Int) -> kotlin.Unit {
+        return { i ->
+            require(minVal <= i, { "Must not be less than ${minVal}" })
+            require(i <= maxVal, { "Must not be greater than ${maxVal}" })
+        }
+    }
+
+    /// Create a constrained decimal using the constructor provided
+    /// Return Error if input is less than minVal or more than maxVal
+    fun requireDoubleInBetween(
+        minVal: Double,
+        maxVal: Double,
+    ): (Double) -> kotlin.Unit {
+        return { i: Double ->
+            require(minVal <= i, { "Must not be less than ${minVal}" })
+            require(i <= maxVal, { "Must not be greater than ${maxVal}" })
+        }
+    }
+
+    /// Create a constrained string using the constructor provided
+    /// Return Error if input is null. empty, or does not match the regex pattern
+    fun requireStringLike(
+        pattern: String,
+    ): (String) -> kotlin.Unit {
+        return { str ->
+            require(!str.isNullOrEmpty(), { isEmptyStringErrorMessage })
+            require(pattern.toRegex().matches(str), { "'${str}' must match the pattern '${pattern}'" })
+        }
+    }
+}

--- a/src/test/kotlin/org/ontheground/dmmf/ordertaking/EmailAddressSpec.kt
+++ b/src/test/kotlin/org/ontheground/dmmf/ordertaking/EmailAddressSpec.kt
@@ -1,0 +1,42 @@
+package org.ontheground.dmmf.ordertaking
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.should
+import io.kotest.matchers.string.contain
+import io.kotest.matchers.string.endWith
+import io.kotest.matchers.string.startWith
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+
+class EmailAddressSpec : DescribeSpec({
+
+    describe("EmailAddress") {
+        context("문자열에 @ 가 포함된 경우,") {
+            val emailAddress = EmailAddress("foo@bar")
+            it("EmailAddress 객체가 정상적으로 생성된다.") {
+                emailAddress.shouldBeInstanceOf<EmailAddress>()
+            }
+        }
+
+        context("문자열에 @ 가 없는 경우,") {
+            val exception = shouldThrow<IllegalArgumentException> {
+                EmailAddress("foobar")
+            }
+
+            it("EmailAddress 객체 생성에 실패한다.") {
+                exception.message should endWith("must match the pattern '.+@.+'")
+            }
+        }
+
+        context("문자열이 비어있는 경우,") {
+            val exception = shouldThrow<IllegalArgumentException> {
+                EmailAddress("")
+            }
+
+            it("Value 객체 생성에 실패한다.") {
+                exception.message should startWith("Must not be null or empty")
+            }
+        }
+    }
+})

--- a/src/test/kotlin/org/ontheground/dmmf/ordertaking/String50Spec.kt
+++ b/src/test/kotlin/org/ontheground/dmmf/ordertaking/String50Spec.kt
@@ -1,0 +1,80 @@
+package org.ontheground.dmmf.ordertaking
+
+import arrow.core.Either
+import arrow.core.Option
+import io.kotest.assertions.arrow.core.shouldBeLeft
+import io.kotest.assertions.arrow.core.shouldBeNone
+import io.kotest.assertions.arrow.core.shouldBeRight
+import io.kotest.assertions.arrow.core.shouldBeSome
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.should
+import io.kotest.matchers.string.startWith
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+
+class String50Spec : DescribeSpec({
+
+    describe("String50") {
+        context("문자열 길이가 50 이하인 경우,") {
+            val lessThen50String = StringGenerator.generate(50)
+
+            val string50 = String50(lessThen50String)
+            it("String50 객체가 정상적으로 생성된다.") {
+                string50.shouldBeInstanceOf<String50>()
+            }
+        }
+
+        context("문자열 길이가 50 초과하는 경우,") {
+            val greaterThen50 = StringGenerator.generate(51)
+
+            val exception = shouldThrow<IllegalArgumentException> {
+                String50(greaterThen50)
+            }
+
+            it("String50 객체 생성에 실패한다.") {
+                exception.message should startWith("Must not be more than 50 chars")
+            }
+        }
+
+        context("문자열이 비어있는 경우,") {
+            val exception = shouldThrow<IllegalArgumentException> {
+                String50("")
+            }
+
+            it("Value 객체 생성에 실패한다.") {
+                exception.message should startWith("Must not be null or empty")
+            }
+        }
+    }
+
+    describe("createOption") {
+        context("문자열 길이가 50 이하인 경우,") {
+            val lessThen50String = StringGenerator.generate(50)
+
+            val string50 = String50.createOption(lessThen50String)
+            it("Either.Right.String50 를 응답한다.") {
+                string50.shouldBeRight().shouldBeSome()
+            }
+        }
+
+        context("문자열 길이가 50 초과하는 경우,") {
+            val greaterThen50 = StringGenerator.generate(51)
+            val string50OrThrowable = String50.createOption(greaterThen50)
+
+            it("Either.Left 를 응답한다.") {
+                string50OrThrowable.shouldBeLeft()
+            }
+        }
+
+        context("문자열이 비어있는 경우,") {
+            val string50: Either<Throwable, Option<String50>> = String50.createOption("")
+
+            it("Either.Right.None 을 응답한다.") {
+                string50.shouldBeRight().shouldBeNone()
+            }
+        }
+    }
+
+
+})

--- a/src/test/kotlin/org/ontheground/dmmf/ordertaking/StringGenerator.kt
+++ b/src/test/kotlin/org/ontheground/dmmf/ordertaking/StringGenerator.kt
@@ -1,0 +1,11 @@
+package org.ontheground.dmmf.ordertaking
+
+object StringGenerator {
+
+    fun generate(length: Int): String {
+        val charset = ('a'..'z')
+        return (1..length)
+            .map { charset.random() }
+            .joinToString("")
+    }
+}


### PR DESCRIPTION
https://github.com/on-the-ground/domain-modeling-made-functional-kotlin/pull/3  기반으로 SimpleTypes 추가했습니다.

유선상으로 코틀린에서 fieldName 이 불필요한 것 같다고 논의했던 부분을 일부 반영했습니다.
- fieldName 을 사용하지 않도록 변경하니 invoke 를 사용할 필요 없을 것 같아 기본 생성자로 초기화 할 수 있도록 변경했습니다.
- String50, EmailAddress 타입에 반영되어있습니다.


createProductCode, createOrderQuantity 처럼 별도 함수에서 생성하는 케이스들이 있는데요.
이런 함수들도 다 변경해도 지장이 없는건지 맥락 파악이 안되서 우선 기존 구성을 유지해뒀습니다.
